### PR TITLE
Fixed problem in concurrent usage of singleton ApsEntityDOM

### DIFF
--- a/engine/src/main/java/com/agiletec/aps/system/common/entity/model/ApsEntity.java
+++ b/engine/src/main/java/com/agiletec/aps/system/common/entity/model/ApsEntity.java
@@ -335,7 +335,7 @@ public class ApsEntity implements IApsEntity {
      * @return The DOM class that generates the XML 
      */
     protected IApsEntityDOM getBuildJDOM() {
-        IApsEntityDOM entityDom = this.getEntityDOM();
+        IApsEntityDOM entityDom = this.getEntityDOM().clone();
         entityDom.init();
         entityDom.setId(String.valueOf(this.getId()));
         entityDom.setTypeCode(this._typeCode);

--- a/engine/src/main/java/com/agiletec/aps/system/common/entity/parse/ApsEntityDOM.java
+++ b/engine/src/main/java/com/agiletec/aps/system/common/entity/parse/ApsEntityDOM.java
@@ -18,6 +18,8 @@ import java.io.Serializable;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.output.XMLOutputter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.agiletec.aps.system.common.entity.ApsEntityManager;
 
@@ -32,6 +34,25 @@ import com.agiletec.aps.system.common.entity.ApsEntityManager;
  * @author M.Morini - S.Didaci - E.Santoboni
  */
 public class ApsEntityDOM implements IApsEntityDOM, Serializable {
+	
+	private static final Logger _logger =  LoggerFactory.getLogger(ApsEntityDOM.class);
+	
+	@Override
+	public ApsEntityDOM clone() {
+		ApsEntityDOM copy = null;
+		try {
+			copy = this.getClass().newInstance();
+			this.copyInto(copy);
+		} catch (Throwable t) {
+			_logger.error("Error cloning {}" + this.getClass(), t);
+			throw new RuntimeException("Error cloning " + this.getClass(), t);
+		}
+		return copy;
+	}
+	
+	protected void copyInto(IApsEntityDOM copy) {
+		copy.setRootElementName(this._rootElementName);
+	}
 	
 	/**
 	 * 

--- a/engine/src/main/java/com/agiletec/aps/system/common/entity/parse/IApsEntityDOM.java
+++ b/engine/src/main/java/com/agiletec/aps/system/common/entity/parse/IApsEntityDOM.java
@@ -20,7 +20,9 @@ import org.jdom.Element;
  * @author E.Santoboni
  */
 public interface IApsEntityDOM {
-
+	
+	public IApsEntityDOM clone();
+	
 	/**
 	 * DOM initialization.
 	 * Method to invoke	when fields valorization is starting.


### PR DESCRIPTION
Added a method clone in ApsEntityDOM, invoked just before building the DOM.
The method instantiate the current class (ex: ContentDOM or FormDOM) and copy only the rootElementName so, if necessary, you only need to extend the method copyInto(IApsEntityDOM).
