### PR TITLE
multiple code improvements: squid:CommentedOutCodeLine, squid:S1213, squid:S1192, squid:UselessParenthesesCheck, squid:S00122, squid:S1066, squid:S1170, squid:S2130

### DIFF
--- a/portal-ui/src/main/java/com/agiletec/aps/system/services/controller/ControllerManager.java
+++ b/portal-ui/src/main/java/com/agiletec/aps/system/services/controller/ControllerManager.java
@@ -35,85 +35,6 @@ public class ControllerManager extends AbstractService {
 
 	private static final Logger _logger = LoggerFactory.getLogger(ControllerManager.class);
 	
-	@Override
-	public void init() throws Exception {
-		_logger.debug("{}: initialized {} controller services", this.getClass().getName(), this.getControllerServices().size());
-	}
-	
-	/**
-	 * Esegue le azioni conseguenti alla richiesta del client.
-	 * L'esecuzione è realizzata invocando in sequenza
-	 * i sottoservizi di controllo definiti in configurazione (implementano 
-	 * ControlServiceInterface); ogni sottoservizio termina con un valore di
-	 * ritorno compreso fra le costanti definite in questa classe. Il valore di
-	 * uscita di ogni sottoservizio è inviato in ingresso al sottoservizio
-	 * successivo. Il valore di ritorno dell'ultimo sottoservizio eseguito 
-	 * è restituito al chiamante.<br>
-	 * Le regole sono:
-	 * <ul>
-	 * <li> i sottoservizi non devono lanciare eccezioni;
-	 * <li> se un sottoservizio riceve in ingresso ERROR deve terminare
-	 * immediatamente restituendo ERROR, a meno che non sia un servizio di
-	 * gestione degli errori;
-	 * <li> se un servizio restituisce OUTPUT o REDIRECT o SYS_ERROR la sequenza
-	 * di esecuzione termina;
-	 * <li> se un servizio restituisce CONTINUE la sequenza continua.
-	 * </ul>
-	 * @param reqCtx Il contesto della richiesta.
-	 * @return Uno dei valori definiti dalle costanti della classe.
-	 */
-	public int service(RequestContext reqCtx) {
-		int status = INVALID_STATUS;
-		int srvIndex = 0;
-		try {
-			do {
-				ControlServiceInterface srv = this.getControllerServices().get(srvIndex);
-				srvIndex++;
-				status = srv.service(reqCtx, status);
-			} while (srvIndex < this.getControllerServices().size()
-					&& status != OUTPUT 
-					&& status != REDIRECT 
-					&& status != SYS_ERROR);
-		} catch (Throwable t) {
-			_logger.error("generic error", t);
-			//ApsSystemUtils.logThrowable(t, this, "service");
-			status = SYS_ERROR;
-		}
-		return status;
-	}
-	
-	/**
-	 * Restituisce una descrizione dello stato passato come argomento.
-	 * @param status Lo stato di cui si vuole la descrizione. 
-	 * Deve essere una delle costanti di questa classe.
-	 * @return La descrizione dello stato, oppure "non definito" 
-	 * se lo stato non ha un valore previsto.
-	 */
-	public static String getStatusDescription(int status) {
-		switch (status) {
-			case INVALID_STATUS: return "INVALID_STATUS";
-			case OUTPUT: return "OUTPUT";
-			case REDIRECT: return "REDIRECT";
-			case ERROR: return "ERROR";
-			case CONTINUE: return "CONTINUE";
-			case RESTART: return "RESTART";
-			case SYS_ERROR: return "SYS_ERROR";
-			default: return "non definito";
-		}
-	}
-	
-	protected List<ControlServiceInterface> getControllerServices() {
-		return _controllerServices;
-	}
-	public void setControllerServices(List<ControlServiceInterface> controllerServices) {
-		this._controllerServices = controllerServices;
-	}
-	
-	/**
-	 * La lista interna dei sottoservizi di controllo
-	 */
-	private List<ControlServiceInterface> _controllerServices;
-	
 	/**
 	 * Stato di uscita dei sottoservizi di controllo: stato non valido. E'
 	 * il valore iniziale, passato in ingresso al primo sottoservizio.
@@ -156,4 +77,81 @@ public class ControllerManager extends AbstractService {
 	 */
 	public static final int SYS_ERROR = 6;
 	
+	/**
+	 * La lista interna dei sottoservizi di controllo
+	 */
+	private List<ControlServiceInterface> _controllerServices;
+	
+	@Override
+	public void init() throws Exception {
+		_logger.debug("{}: initialized {} controller services", this.getClass().getName(), this.getControllerServices().size());
+	}
+	
+	/**
+	 * Esegue le azioni conseguenti alla richiesta del client.
+	 * L'esecuzione è realizzata invocando in sequenza
+	 * i sottoservizi di controllo definiti in configurazione (implementano 
+	 * ControlServiceInterface); ogni sottoservizio termina con un valore di
+	 * ritorno compreso fra le costanti definite in questa classe. Il valore di
+	 * uscita di ogni sottoservizio è inviato in ingresso al sottoservizio
+	 * successivo. Il valore di ritorno dell'ultimo sottoservizio eseguito 
+	 * è restituito al chiamante.<br>
+	 * Le regole sono:
+	 * <ul>
+	 * <li> i sottoservizi non devono lanciare eccezioni;
+	 * <li> se un sottoservizio riceve in ingresso ERROR deve terminare
+	 * immediatamente restituendo ERROR, a meno che non sia un servizio di
+	 * gestione degli errori;
+	 * <li> se un servizio restituisce OUTPUT o REDIRECT o SYS_ERROR la sequenza
+	 * di esecuzione termina;
+	 * <li> se un servizio restituisce CONTINUE la sequenza continua.
+	 * </ul>
+	 * @param reqCtx Il contesto della richiesta.
+	 * @return Uno dei valori definiti dalle costanti della classe.
+	 */
+	public int service(RequestContext reqCtx) {
+		int status = INVALID_STATUS;
+		int srvIndex = 0;
+		try {
+			do {
+				ControlServiceInterface srv = this.getControllerServices().get(srvIndex);
+				srvIndex++;
+				status = srv.service(reqCtx, status);
+			} while (srvIndex < this.getControllerServices().size()
+					&& status != OUTPUT 
+					&& status != REDIRECT 
+					&& status != SYS_ERROR);
+		} catch (Throwable t) {
+			_logger.error("generic error", t);
+			status = SYS_ERROR;
+		}
+		return status;
+	}
+	
+	/**
+	 * Restituisce una descrizione dello stato passato come argomento.
+	 * @param status Lo stato di cui si vuole la descrizione. 
+	 * Deve essere una delle costanti di questa classe.
+	 * @return La descrizione dello stato, oppure "non definito" 
+	 * se lo stato non ha un valore previsto.
+	 */
+	public static String getStatusDescription(int status) {
+		switch (status) {
+			case INVALID_STATUS: return "INVALID_STATUS";
+			case OUTPUT: return "OUTPUT";
+			case REDIRECT: return "REDIRECT";
+			case ERROR: return "ERROR";
+			case CONTINUE: return "CONTINUE";
+			case RESTART: return "RESTART";
+			case SYS_ERROR: return "SYS_ERROR";
+			default: return "non definito";
+		}
+	}
+	
+	protected List<ControlServiceInterface> getControllerServices() {
+		return _controllerServices;
+	}
+	public void setControllerServices(List<ControlServiceInterface> controllerServices) {
+		this._controllerServices = controllerServices;
+	}
 }

--- a/portal-ui/src/main/java/org/entando/entando/aps/servlet/ControllerServlet.java
+++ b/portal-ui/src/main/java/org/entando/entando/aps/servlet/ControllerServlet.java
@@ -50,6 +50,9 @@ import org.slf4j.LoggerFactory;
 public class ControllerServlet extends freemarker.ext.servlet.FreemarkerServlet {
 	
 	private static final Logger _logger = LoggerFactory.getLogger(ControllerServlet.class);
+	private static final String ATTR_APPLICATION_MODEL = ".freemarker.Application";
+	private static final String ATTR_JSP_TAGLIBS_MODEL = ".freemarker.JspTaglibs";
+	private static final String SERVICE_NOT_AVAILABLE = "Service not available";
 	
 	@Override
     protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -92,7 +95,7 @@ public class ControllerServlet extends freemarker.ext.servlet.FreemarkerServlet 
             this.outputError(reqCtx, response);
         } else {
         	_logger.error("Error: final status = {} - request: {}", ControllerManager.getStatusDescription(status),request.getServletPath());
-            throw new ServletException("Service not available");
+            throw new ServletException(SERVICE_NOT_AVAILABLE);
         }
         return;
     }
@@ -102,7 +105,7 @@ public class ControllerServlet extends freemarker.ext.servlet.FreemarkerServlet 
 			HttpServletRequest request, HttpServletResponse response) throws TemplateModelException {
 		TemplateModel template = super.createModel(wrapper, servletContext, request, response);
 		if (template instanceof AllHttpScopesHashModel) {
-			AllHttpScopesHashModel hashModel = ((AllHttpScopesHashModel) template);
+			AllHttpScopesHashModel hashModel = (AllHttpScopesHashModel) template;
 			ServletContextHashModel servletContextModel = (ServletContextHashModel) hashModel.get(KEY_APPLICATION);
 			if (null == servletContextModel.getServlet()) {
 				ServletContextHashModel newServletContextModel = new ServletContextHashModel(this, wrapper);
@@ -122,7 +125,7 @@ public class ControllerServlet extends freemarker.ext.servlet.FreemarkerServlet 
             String url = (String) reqCtx.getExtraParam(RequestContext.EXTRAPAR_REDIRECT_URL);
             response.sendRedirect(url);
         } catch (Exception e) {
-            throw new ServletException("Service not available", e);
+            throw new ServletException(SERVICE_NOT_AVAILABLE, e);
         }
     }
     
@@ -138,11 +141,8 @@ public class ControllerServlet extends freemarker.ext.servlet.FreemarkerServlet 
             }
         } catch (IOException e) {
         	_logger.error("outputError", e);
-            throw new ServletException("Service not available");
+            throw new ServletException(SERVICE_NOT_AVAILABLE);
         }
     }
     
-	private static final String ATTR_APPLICATION_MODEL = ".freemarker.Application";
-	private static final String ATTR_JSP_TAGLIBS_MODEL = ".freemarker.JspTaglibs";
-	
 }

--- a/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/ContentPreviewAction.java
+++ b/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/ContentPreviewAction.java
@@ -41,6 +41,18 @@ public class ContentPreviewAction extends AbstractContentAction implements Servl
 
 	private static final Logger _logger = LoggerFactory.getLogger(ContentPreviewAction.class);
 	
+	public static final String PAGE_CODE_PARAM_PREFIX = "jacmsPreviewActionPageCode";
+	
+	public static final String LANG_CODE_PARAM_PREFIX = "jacmsPreviewActionLangCode";
+	
+	private HttpServletResponse _response;
+	
+	private String _previewPageCode;
+	private String _previewLangCode;
+	
+	private IPageManager _pageManager;
+	private IURLManager _urlManager;
+	
 	public String preview() {
 		Content content = this.getContent();
 		this.getContentActionHelper().updateEntity(content, this.getRequest());
@@ -80,7 +92,9 @@ public class ContentPreviewAction extends AbstractContentAction implements Servl
 	public String executePreview() {
 		try {
 			String pageDestCode = this.getCheckPageDestinationCode();
-			if (null == pageDestCode) return INPUT;
+			if (null == pageDestCode) {
+				return INPUT;
+			}
 			this.prepareForward(pageDestCode);
 			this.getRequest().setCharacterEncoding("UTF-8");
 		} catch (Throwable t) {
@@ -157,17 +171,5 @@ public class ContentPreviewAction extends AbstractContentAction implements Servl
 	public void setUrlManager(IURLManager urlManager) {
 		this._urlManager = urlManager;
 	}
-	
-	private HttpServletResponse _response;
-	
-	private String _previewPageCode;
-	private String _previewLangCode;
-	
-	private IPageManager _pageManager;
-	private IURLManager _urlManager;
-	
-	public static final String PAGE_CODE_PARAM_PREFIX = "jacmsPreviewActionPageCode";
-	
-	public static final String LANG_CODE_PARAM_PREFIX = "jacmsPreviewActionLangCode";
 	
 }

--- a/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/executor/PreviewWidgetExecutorAspect.java
+++ b/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/executor/PreviewWidgetExecutorAspect.java
@@ -38,6 +38,8 @@ public class PreviewWidgetExecutorAspect extends WidgetExecutorService {
 	
 	private static final Logger _logger = LoggerFactory.getLogger(PreviewWidgetExecutorAspect.class);
 	
+	private static final String CONTENT_VIEWER_JSP="/WEB-INF/plugins/jacms/apsadmin/jsp/content/preview/content_viewer.jsp";
+	
 	@After("execution(* org.entando.entando.aps.system.services.controller.executor.WidgetExecutorService.service(..)) && args(reqCtx)")
 	public void checkContentPreview(RequestContext reqCtx) {
 		HttpServletRequest request = reqCtx.getRequest();
@@ -58,16 +60,15 @@ public class PreviewWidgetExecutorAspect extends WidgetExecutorService {
 			Widget[] widgets = currentPage.getWidgets();
 			for (int frame = 0; frame < widgets.length; frame++) {
 				Widget widget = widgets[frame];
-				if (widget != null && "viewerConfig".equals(widget.getType().getAction())) {
-					if ((currentPage.getCode().equals(contentOnSession.getViewPage()) && (widget.getConfig() == null || widget.getConfig().size() == 0)) 
-							|| (widget.getConfig() != null && widget.getConfig().get("contentId") != null && widget.getConfig().get("contentId").equals(contentOnSession.getId()))) {
-						reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_WIDGET, widget);
-						reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_FRAME, new Integer(frame));
-						String output = super.extractJspOutput(reqCtx, CONTENT_VIEWER_JSP);
-						String[] widgetOutput = (String[]) reqCtx.getExtraParam("ShowletOutput");
-						widgetOutput[frame] = output; 
-						return;
-					}
+				if (widget != null && "viewerConfig".equals(widget.getType().getAction()) &&
+					(currentPage.getCode().equals(contentOnSession.getViewPage()) && (widget.getConfig() == null || widget.getConfig().size() == 0)) 
+						|| (widget.getConfig() != null && widget.getConfig().get("contentId") != null && widget.getConfig().get("contentId").equals(contentOnSession.getId()))) {
+					reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_WIDGET, widget);
+					reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_FRAME, new Integer(frame));
+					String output = super.extractJspOutput(reqCtx, CONTENT_VIEWER_JSP);
+					String[] widgetOutput = (String[]) reqCtx.getExtraParam("ShowletOutput");
+					widgetOutput[frame] = output; 
+					return;
 				}
 			}
 		} catch (Throwable t) {
@@ -76,7 +77,5 @@ public class PreviewWidgetExecutorAspect extends WidgetExecutorService {
 			throw new RuntimeException(msg, t);
 		}
 	}
-	
-	private final String CONTENT_VIEWER_JSP="/WEB-INF/plugins/jacms/apsadmin/jsp/content/preview/content_viewer.jsp";
 	
 }

--- a/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/preview/ContentPreviewDispenser.java
+++ b/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/preview/ContentPreviewDispenser.java
@@ -42,6 +42,8 @@ public class ContentPreviewDispenser extends BaseContentDispenser {
 	
 	private static final Logger _logger = LoggerFactory.getLogger(ContentPreviewDispenser.class);
 	
+	private ILangManager _langManager;
+	
 	@Override
 	public ContentRenderizationInfo getRenderizationInfo(String contentId, long modelId, String langCode, RequestContext reqCtx) {
 		PublicContentAuthorizationInfo authInfo = null;
@@ -91,7 +93,5 @@ public class ContentPreviewDispenser extends BaseContentDispenser {
 	public void setLangManager(ILangManager langManager) {
 		this._langManager = langManager;
 	}
-	
-	private ILangManager _langManager;
 	
 }

--- a/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/preview/ContentPreviewViewerHelper.java
+++ b/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/preview/ContentPreviewViewerHelper.java
@@ -52,11 +52,11 @@ public class ContentPreviewViewerHelper extends ContentViewerHelper {
 			Widget widget = (Widget) reqCtx.getExtraParam(SystemConstants.EXTRAPAR_CURRENT_WIDGET);
 			Content contentOnSession = (Content) request.getSession()
 					.getAttribute(ContentActionConstants.SESSION_PARAM_NAME_CURRENT_CONTENT_PREXIX + contentOnSessionMarker);
-			contentId = (contentOnSession.getId() == null ? contentOnSession.getTypeCode()+"123" : contentOnSession.getId());
+			contentId = contentOnSession.getId() == null ? contentOnSession.getTypeCode()+"123" : contentOnSession.getId();
 			ApsProperties widgetConfig = widget.getConfig();
 			modelId = this.extractModelId(contentId, modelId, widgetConfig);
 			if (null != contentId && null != modelId) {
-				long longModelId = new Long(modelId).longValue();
+				long longModelId = Long.parseLong(modelId);
 				this.setStylesheet(longModelId, reqCtx);
 				ContentRenderizationInfo renderizationInfo = this.getContentDispenser().getRenderizationInfo(contentId, longModelId, langCode, reqCtx);
 	            if (null == renderizationInfo) {
@@ -70,7 +70,6 @@ public class ContentPreviewViewerHelper extends ContentViewerHelper {
 			}
 		} catch (Throwable t) {
 			_logger.error("error loading rendered content for preview", t);
-			//ApsSystemUtils.logThrowable(t, this, "getRenderedContent");
 			throw new ApsSystemException("error loading rendered content for preview", t);
 		}
 		return renderedContent;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1192 - String literals should not be duplicated.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S00122 - Statements should be on separate lines.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S1170 - Public constants should be declared "static final" rather than merely "final".
squid:S2130 - Parsing should be used to convert "Strings" to primitives.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ACommentedOutCodeLine
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1066
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1170
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2130
Please let me know if you have any questions.
George Kankava
