### PR TITLE
multiple code improvements: squid:S1213, squid:S1854, squid:CommentedOutCodeLine, squid:S00122

### DIFF
--- a/portal-ui/src/main/java/com/agiletec/aps/system/services/controller/control/Authenticator.java
+++ b/portal-ui/src/main/java/com/agiletec/aps/system/services/controller/control/Authenticator.java
@@ -37,6 +37,8 @@ public class Authenticator extends AbstractControlService {
 
 	private static final Logger _logger = LoggerFactory.getLogger(Authenticator.class);
 
+    private IUserManager _userManager;
+    private IAuthenticationProviderManager _authenticationProvider;
 	
 	@Override
     public void afterPropertiesSet() throws Exception {
@@ -58,7 +60,7 @@ public class Authenticator extends AbstractControlService {
 	@Override
     public int service(RequestContext reqCtx, int status) {
     	_logger.debug("Invoked {}", this.getClass().getName());
-        int retStatus = ControllerManager.INVALID_STATUS;
+        int retStatus;
         if (status == ControllerManager.ERROR) {
         	return status;
         }
@@ -118,7 +120,5 @@ public class Authenticator extends AbstractControlService {
 		this._authenticationProvider = authenticationProvider;
 	}
 	
-    private IUserManager _userManager;
-    private IAuthenticationProviderManager _authenticationProvider;
-    
+
 }

--- a/portal-ui/src/main/java/com/agiletec/aps/system/services/controller/control/RequestValidator.java
+++ b/portal-ui/src/main/java/com/agiletec/aps/system/services/controller/control/RequestValidator.java
@@ -50,6 +50,17 @@ public class RequestValidator extends AbstractControlService {
 
 	private static final Logger _logger = LoggerFactory.getLogger(RequestValidator.class);
 	
+	@Deprecated
+	protected Pattern _oldPattern = Pattern.compile("^/(\\w+)/(\\w+)\\Q.wp\\E");
+	
+	protected Pattern _pattern = Pattern.compile("^/(\\w+)/(\\w+)\\Q.page\\E");
+	
+	protected Pattern _patternFullPath = Pattern.compile("^/pages/(\\w+)((/\\w+)*)");
+	
+	private ILangManager _langManager;
+	private IPageManager _pageManager;
+	private ConfigInterface configManager;
+
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		_logger.debug("{} ready", this.getClass().getName());
@@ -64,7 +75,7 @@ public class RequestValidator extends AbstractControlService {
 	@Override
 	public int service(RequestContext reqCtx, int status) {
 		_logger.debug("{} invoked", this.getClass().getName());
-		int retStatus = ControllerManager.INVALID_STATUS;
+		int retStatus;
 		// Se si è verificato un errore in un altro sottoservizio, termina subito
 		if (status == ControllerManager.ERROR) {
 			return status;
@@ -126,7 +137,9 @@ public class RequestValidator extends AbstractControlService {
 				}
 			}
 		}
-		if (!ok) return false;
+		if (!ok) {
+			return false;
+		}
 		reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_LANG, lang);
 		reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_PAGE, page);
 		return true;
@@ -155,9 +168,6 @@ public class RequestValidator extends AbstractControlService {
 		String pageCode = matcher.group(3).substring(1);
 		IPage tempPage = this.getPageManager().getPage(pageCode);
 		if (null != tempPage) {
-			//la pagina esiste ed è di livello 1
-			//if(tempPage.getParentCode().equals(rootCode)) return tempPage;
-			//la pagina è di livello superiore al primo e il path è corretto
 			String fullPath = matcher.group(2).substring(1).trim();
 			String createdlFullPath = PageUtils.getFullPath(tempPage, "/").toString();
 			if (null != tempPage && createdlFullPath.equals(fullPath) ){
@@ -208,16 +218,5 @@ public class RequestValidator extends AbstractControlService {
 	public void setConfigManager(ConfigInterface configService) {
 		this.configManager = configService;
 	}
-	
-	private ILangManager _langManager;
-	private IPageManager _pageManager;
-	private ConfigInterface configManager;
-	
-	@Deprecated
-	protected Pattern _oldPattern = Pattern.compile("^/(\\w+)/(\\w+)\\Q.wp\\E");
-	
-	protected Pattern _pattern = Pattern.compile("^/(\\w+)/(\\w+)\\Q.page\\E");
-	
-	protected Pattern _patternFullPath = Pattern.compile("^/pages/(\\w+)((/\\w+)*)");
 	
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1854 - Dead stores should be removed.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S00122 - Statements should be on separate lines.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1854
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ACommentedOutCodeLine
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
Please let me know if you have any questions.
George Kankava
