### PR TITLE
Update FilterUtils.java

### DIFF
--- a/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/util/FilterUtils.java
+++ b/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/util/FilterUtils.java
@@ -82,7 +82,7 @@ public class FilterUtils extends BaseFilterUtils {
 				String toStringFilter = fullFilterString.substring(1, fullFilterString.length()-1);
 				Properties properties = getProperties(toStringFilter, DEFAULT_FILTER_PARAM_SEPARATOR);
 				UserFilterOptionBean filterBean = new UserFilterOptionBean(properties, prototype, currentFrame, currentLang, dateFormat, request);
-                                if (filterBean.getFormFieldValues().isEmpty() && filterBean.isAttributeFilter() && !prototype.getAttributeMap().get(filterBean.getKey()).isRequired()){
+                                if (filterBean.getFormFieldValues()!=null && filterBean.getFormFieldValues().isEmpty() && filterBean.isAttributeFilter() && !prototype.getAttributeMap().get(filterBean.getKey()).isRequired()){
                                     // Skippo l'aggiunta del filtro perchè è un campo non obbligatorio e se non valorizzo il filtro, verrebbero ignorati tutti i risultati con questo campo nullo (rif IS NOT NULL) anche se la ricerca era per altri campi
                                 }else{
                                     list.add(filterBean);

--- a/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/util/FilterUtils.java
+++ b/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/util/FilterUtils.java
@@ -82,7 +82,11 @@ public class FilterUtils extends BaseFilterUtils {
 				String toStringFilter = fullFilterString.substring(1, fullFilterString.length()-1);
 				Properties properties = getProperties(toStringFilter, DEFAULT_FILTER_PARAM_SEPARATOR);
 				UserFilterOptionBean filterBean = new UserFilterOptionBean(properties, prototype, currentFrame, currentLang, dateFormat, request);
-				list.add(filterBean);
+                                if (filterBean.getFormFieldValues().isEmpty() && filterBean.isAttributeFilter() && !prototype.getAttributeMap().get(filterBean.getKey()).isRequired()){
+                                    // Skippo l'aggiunta del filtro perchè è un campo non obbligatorio e se non valorizzo il filtro, verrebbero ignorati tutti i risultati con questo campo nullo (rif IS NOT NULL) anche se la ricerca era per altri campi
+                                }else{
+                                    list.add(filterBean);
+                                }
 			} catch (Throwable t) {
 				_logger.error("Error extracting user filter by string '{}' for type '{}'", fullFilterString, prototype.getTypeCode(), t);
 				//ApsSystemUtils.logThrowable(t, FilterUtils.class, "getUserFilters", "Error extracting user filter by string '" + fullFilterString + "' for type '" + prototype.getTypeCode() + "'");


### PR DESCRIPTION
Il filtro per attributi mi pone un grosso problema nel caso in cui il filtro non viene valorizzato e l'attributo non è obbligatorio. In questo scenario la query viene comunque creata andando ad impostare che l'attributo deve essere NOT NULL. Dal momento che però tale campo non è impostato come obbligatio può essere nullo, la query genera un risultato errato.
