### PR TITLE
Fixed a bug in rendering of a content preview

### DIFF
--- a/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/dispenser/BaseContentDispenser.java
+++ b/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/dispenser/BaseContentDispenser.java
@@ -122,7 +122,7 @@ public class BaseContentDispenser extends AbstractService implements IContentDis
 	
 	@Override
 	public void resolveLinks(ContentRenderizationInfo renderizationInfo, RequestContext reqCtx) {
-		if (null == renderizationInfo || null == reqCtx) {
+		if (null == renderizationInfo) {
 			return;
 		}
 		try {

--- a/engine/src/main/java/org/entando/entando/plugins/jacms/aps/system/services/api/ApiContentInterface.java
+++ b/engine/src/main/java/org/entando/entando/plugins/jacms/aps/system/services/api/ApiContentInterface.java
@@ -118,9 +118,9 @@ public class ApiContentInterface extends AbstractCmsApiInterface {
             render.append(this.getItemsStartElement());
             for (int i = 0; i < contentsId.size(); i++) {
                 render.append(this.getItemStartElement());
-				ContentRenderizationInfo renderizationInfo = this.getContentDispenser().getRenderizationInfo(contentsId.get(i), modelIdInteger, langCode, null);
-	            if (null != renderizationInfo) {
-					render.append(renderizationInfo.getCachedRenderedContent());
+                String renderedContent = this.getRenderedContent(contentsId.get(i), modelIdInteger, langCode);
+	            if (null != renderedContent) {
+					render.append(renderedContent);
 	            }
                 render.append(this.getItemEndElement());
             }
@@ -171,14 +171,10 @@ public class ApiContentInterface extends AbstractCmsApiInterface {
             }
             Content mainContent = this.getPublicContent(id);
             Integer modelIdInteger = this.checkModel(modelId, mainContent);
-            if (null == modelIdInteger) {
-                return null;
+            if (null != modelIdInteger) {
+                String langCode = properties.getProperty(SystemConstants.API_LANG_CODE_PARAMETER);
+                render = this.getRenderedContent(id, modelIdInteger, langCode);
             }
-            String langCode = properties.getProperty(SystemConstants.API_LANG_CODE_PARAMETER);
-			ContentRenderizationInfo renderizationInfo = this.getContentDispenser().getRenderizationInfo(id, modelIdInteger, langCode, null);
-			if (null != renderizationInfo) {
-				return renderizationInfo.getCachedRenderedContent();
-			}
         } catch (ApiException ae) {
             throw ae;
         } catch (Throwable t) {
@@ -187,6 +183,16 @@ public class ApiContentInterface extends AbstractCmsApiInterface {
         }
         return render;
     }
+	
+	protected String getRenderedContent(String id, int modelId, String langCode) {
+		String renderedContent = null;
+		ContentRenderizationInfo renderizationInfo = this.getContentDispenser().getRenderizationInfo(id, modelId, langCode, null, true);
+		if (null != renderizationInfo) {
+			this.getContentDispenser().resolveLinks(renderizationInfo, null);
+			renderedContent = renderizationInfo.getRenderedContent();
+		}
+		return renderedContent;
+	}
 	
     protected Content getPublicContent(String id) throws ApiException, Throwable {
         Content content = null;

--- a/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/preview/ContentPreviewDispenser.java
+++ b/portal-ui/src/main/java/org/entando/entando/plugins/jacms/apsadmin/content/preview/ContentPreviewDispenser.java
@@ -56,6 +56,12 @@ public class ContentPreviewDispenser extends BaseContentDispenser {
 	
 	@Override
 	public ContentRenderizationInfo getBaseRenderizationInfo(PublicContentAuthorizationInfo authInfo, 
+			String contentId, long modelId, String langCode, UserDetails currentUser, RequestContext reqCtx, boolean cacheable) {
+		return this.getBaseRenderizationInfo(authInfo, contentId, modelId, langCode, currentUser, reqCtx);
+	}
+	
+	@Override
+	public ContentRenderizationInfo getBaseRenderizationInfo(PublicContentAuthorizationInfo authInfo, 
 			String contentId, long modelId, String langCode, UserDetails currentUser, RequestContext reqCtx) {
 		ContentRenderizationInfo renderInfo = null;
 		try {


### PR DESCRIPTION
There was a bug in the content preview, that showed the Content in the DB, instead of the Content in session.

The class

> org.entando.entando.plugins.jacms.apsadmin.content.preview.ContentPreviewDispenser

called the method

> public ContentRenderizationInfo getBaseRenderizationInfo(PublicContentAuthorizationInfo authInfo, 
			String contentId, long modelId, String langCode, UserDetails currentUser, RequestContext reqCtx, boolean cacheable)

of the class

> com.agiletec.plugins.jacms.aps.system.services.dispenser.BaseContentDispenser

containing the instruction

> Content contentToRender = this.getContentManager().loadContent(contentId, true, cacheable);

A solution to avoid this error is to override this method as shown:

> @Override
	public ContentRenderizationInfo getBaseRenderizationInfo(PublicContentAuthorizationInfo authInfo, 
			String contentId, long modelId, String langCode, UserDetails currentUser, RequestContext reqCtx, boolean cacheable) {
		return this.getBaseRenderizationInfo(authInfo, contentId, modelId, langCode, currentUser, reqCtx);
	}

