### PR TITLE
Javadoc plugin configuration based on profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,17 @@
 		<name>Entando Inc.</name>
 		<url>http://www.entando.com/</url>
 	</organization>
+	<profiles>
+            <profile>
+                <id>java8</id>
+                <activation>
+                   <jdk>[1.8,)</jdk>
+                </activation>
+                <properties>
+                    <javadoc.opts>-Xdoclint:none</javadoc.opts>
+                </properties>
+             </profile>
+        </profiles>
 	<properties>
 		
 		<!--
@@ -124,10 +135,8 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
-						<!-- uncomment this configuration if you want to use jdk 1.8 -->
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-							<failOnError>false</failOnError>
+							<additionalparam>${javadoc.opts}</additionalparam>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
Additional param configuration for javadoc plugin managed by profile with automatic activation instead of uncomment / failOnError. The profile java8-doclint-disabled evaluate property javadoc.opts with value -Xdoclint:none required on java 8 environment 