### PR TITLE
En 1866 fix content list cache key

### DIFF
--- a/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/helper/BaseContentListHelper.java
+++ b/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/helper/BaseContentListHelper.java
@@ -144,6 +144,15 @@ public class BaseContentListHelper implements IContentListHelper {
     }
 
     protected static String buildCacheKey(IContentListBean bean, Collection<String> userGroupCodes) {
+        return buildStringBuilderCacheKey(bean, userGroupCodes).toString();
+    }
+
+    protected static StringBuilder buildStringBuilderCacheKey(IContentListBean bean, UserDetails user) {
+        Collection<String> userGroupCodes = getAllowedGroupCodes(user);
+        return buildStringBuilderCacheKey(bean, userGroupCodes);
+    }
+
+    protected static StringBuilder buildStringBuilderCacheKey(IContentListBean bean, Collection<String> userGroupCodes) {
         StringBuilder cacheKey = new StringBuilder();
         if (null != bean.getListName()) {
             cacheKey.append("LISTNAME_").append(bean.getListName());
@@ -183,7 +192,7 @@ public class BaseContentListHelper implements IContentListHelper {
                 cacheKey.append("_").append(filter.toString());
             }
         }
-        return cacheKey.toString();
+        return cacheKey;
     }
 
     public static String concatStrings(Collection<String> values, String separator) {

--- a/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/ContentListHelper.java
+++ b/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/ContentListHelper.java
@@ -263,7 +263,12 @@ public class ContentListHelper extends BaseContentListHelper implements IContent
         if (null == filters) {
             return bean.getFilters();
         }
-        EntitySearchFilter[] filtersToReturn = (null != bean.getFilters()) ? Arrays.copyOf(bean.getFilters(), bean.getFilters().length) : new EntitySearchFilter[0];
+        EntitySearchFilter[] filtersToReturn = null;
+        if (null != bean.getFilters()) {
+            filtersToReturn = Arrays.copyOf(bean.getFilters(), bean.getFilters().length);
+        } else {
+            filtersToReturn = new EntitySearchFilter[0];
+        }
         filtersToReturn = ArrayUtils.addAll(filtersToReturn, filters);
         return filtersToReturn;
     }

--- a/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/ContentListHelper.java
+++ b/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/ContentListHelper.java
@@ -15,7 +15,6 @@ package com.agiletec.plugins.jacms.aps.system.services.content.widget;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -34,7 +33,6 @@ import com.agiletec.aps.system.common.entity.helper.IEntityFilterBean;
 import com.agiletec.aps.system.common.entity.model.EntitySearchFilter;
 import com.agiletec.aps.system.common.entity.model.IApsEntity;
 import com.agiletec.aps.system.exception.ApsSystemException;
-import com.agiletec.aps.system.services.group.Group;
 import com.agiletec.aps.system.services.lang.Lang;
 import com.agiletec.aps.system.services.page.IPage;
 import com.agiletec.aps.system.services.page.Widget;
@@ -43,6 +41,8 @@ import com.agiletec.aps.util.ApsProperties;
 import com.agiletec.plugins.jacms.aps.system.services.content.helper.BaseContentListHelper;
 import com.agiletec.plugins.jacms.aps.system.services.content.helper.IContentListFilterBean;
 import com.agiletec.plugins.jacms.aps.system.services.content.widget.util.FilterUtils;
+import java.util.Collections;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.cache.annotation.Cacheable;
 
 /**
@@ -210,7 +210,7 @@ public class ContentListHelper extends BaseContentListHelper implements IContent
             if (null != fullTextResult) {
                 return ListUtils.intersection(fullTextResult, masterContentsId);
             } else {
-                return new ArrayList<String>();
+                return new ArrayList<>();
             }
         } else {
             return masterContentsId;
@@ -218,7 +218,7 @@ public class ContentListHelper extends BaseContentListHelper implements IContent
     }
 
     protected String[] getCategories(String[] categories, ApsProperties config, List<UserFilterOptionBean> userFilters) {
-        Set<String> codes = new HashSet<String>();
+        Set<String> codes = new HashSet<>();
         if (null != categories) {
             for (String category : categories) {
                 codes.add(category);
@@ -283,52 +283,28 @@ public class ContentListHelper extends BaseContentListHelper implements IContent
 
     public static String buildCacheKey(IContentListTagBean bean, RequestContext reqCtx) {
         UserDetails currentUser = (UserDetails) reqCtx.getRequest().getSession().getAttribute(SystemConstants.SESSIONPARAM_CURRENT_USER);
-        Collection<String> userGroupCodes = getAllowedGroupCodes(currentUser);
-        return buildCacheKey(bean.getListName(), userGroupCodes, reqCtx);
-    }
-
-    protected static String buildCacheKey(String listName, Collection<String> userGroupCodes, RequestContext reqCtx) {
+        StringBuilder baseCacheKey = ContentListHelper.buildStringBuilderCacheKey(bean, currentUser);
         IPage page = (null != reqCtx) ? (IPage) reqCtx.getExtraParam(SystemConstants.EXTRAPAR_CURRENT_PAGE) : null;
-        StringBuilder cacheKey = (null != page) ? new StringBuilder(page.getCode()) : new StringBuilder("NOTFOUND");
+        if (null != page) {
+            baseCacheKey.append("_PAGENOTFOUND_");
+        } else {
+            baseCacheKey.append("_PAGE_" + page.getCode());
+        }
         Widget currentWidget = (null != reqCtx) ? (Widget) reqCtx.getExtraParam(SystemConstants.EXTRAPAR_CURRENT_WIDGET) : null;
-        if (null != currentWidget && null != currentWidget.getType()) {
-            cacheKey.append("_").append(currentWidget.getType().getCode());
-        }
-        if (null != reqCtx) {
-            Integer frame = (Integer) reqCtx.getExtraParam(SystemConstants.EXTRAPAR_CURRENT_FRAME);
-            if (null != frame) {
-                cacheKey.append("_").append(frame.intValue());
-            }
-            Lang currentLang = (Lang) reqCtx.getExtraParam(SystemConstants.EXTRAPAR_CURRENT_LANG);
-            if (null != currentLang) {
-                cacheKey.append("_LANG").append(currentLang.getCode()).append("_");
-            }
-        }
-        List<String> groupCodes = new ArrayList<String>(userGroupCodes);
-        if (!groupCodes.contains(Group.FREE_GROUP_NAME)) {
-            groupCodes.add(Group.FREE_GROUP_NAME);
-        }
-        Collections.sort(groupCodes);
-        for (String code : groupCodes) {
-            cacheKey.append("_").append(code);
-        }
         if (null != currentWidget && null != currentWidget.getConfig()) {
             List<String> paramKeys = new ArrayList(currentWidget.getConfig().keySet());
             Collections.sort(paramKeys);
             for (int i = 0; i < paramKeys.size(); i++) {
                 if (i == 0) {
-                    cacheKey.append("_WIDGETPARAM");
+                    baseCacheKey.append("_WIDGETPARAM");
                 } else {
-                    cacheKey.append(",");
+                    baseCacheKey.append(",");
                 }
                 String paramkey = (String) paramKeys.get(i);
-                cacheKey.append(paramkey).append("=").append(currentWidget.getConfig().getProperty(paramkey));
+                baseCacheKey.append(paramkey).append("=").append(currentWidget.getConfig().getProperty(paramkey));
             }
         }
-        if (null != listName) {
-            cacheKey.append("_LISTNAME").append(listName);
-        }
-        return cacheKey.toString();
+        return DigestUtils.md5Hex(baseCacheKey.toString());
     }
 
     @Override

--- a/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/ContentListHelper.java
+++ b/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/ContentListHelper.java
@@ -285,8 +285,8 @@ public class ContentListHelper extends BaseContentListHelper implements IContent
         UserDetails currentUser = (UserDetails) reqCtx.getRequest().getSession().getAttribute(SystemConstants.SESSIONPARAM_CURRENT_USER);
         StringBuilder baseCacheKey = ContentListHelper.buildStringBuilderCacheKey(bean, currentUser);
         IPage page = (null != reqCtx) ? (IPage) reqCtx.getExtraParam(SystemConstants.EXTRAPAR_CURRENT_PAGE) : null;
-        if (null != page) {
-            baseCacheKey.append("_PAGENOTFOUND_");
+        if (null == page) {
+            baseCacheKey.append("_PAGENOTFOUND");
         } else {
             baseCacheKey.append("_PAGE_" + page.getCode());
         }
@@ -304,6 +304,9 @@ public class ContentListHelper extends BaseContentListHelper implements IContent
                 baseCacheKey.append(paramkey).append("=").append(currentWidget.getConfig().getProperty(paramkey));
             }
         }
+        System.out.println("-----------baseCacheKey------------");
+        System.out.println(baseCacheKey);
+        System.out.println("-----------------------");
         return DigestUtils.md5Hex(baseCacheKey.toString());
     }
 

--- a/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/ContentListHelper.java
+++ b/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/ContentListHelper.java
@@ -304,9 +304,6 @@ public class ContentListHelper extends BaseContentListHelper implements IContent
                 baseCacheKey.append(paramkey).append("=").append(currentWidget.getConfig().getProperty(paramkey));
             }
         }
-        System.out.println("-----------baseCacheKey------------");
-        System.out.println(baseCacheKey);
-        System.out.println("-----------------------");
         return DigestUtils.md5Hex(baseCacheKey.toString());
     }
 

--- a/engine/src/test/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/TestContentListHelper.java
+++ b/engine/src/test/java/com/agiletec/plugins/jacms/aps/system/services/content/widget/TestContentListHelper.java
@@ -23,213 +23,301 @@ import com.agiletec.aps.system.RequestContext;
 import com.agiletec.aps.system.SystemConstants;
 import com.agiletec.aps.system.common.entity.model.EntitySearchFilter;
 import com.agiletec.aps.system.exception.ApsSystemException;
+import com.agiletec.aps.system.services.group.Group;
 import com.agiletec.aps.system.services.page.IPage;
 import com.agiletec.aps.system.services.page.IPageManager;
 import com.agiletec.aps.system.services.page.Widget;
 import com.agiletec.aps.util.ApsProperties;
 import com.agiletec.aps.util.DateConverter;
 import com.agiletec.plugins.jacms.aps.system.JacmsSystemConstants;
+import com.agiletec.plugins.jacms.aps.system.services.content.IContentManager;
+import com.agiletec.plugins.jacms.aps.system.services.content.model.Content;
+import java.util.ArrayList;
+import org.apache.commons.collections4.CollectionUtils;
+import org.entando.entando.aps.system.services.cache.ICacheInfoManager;
+import org.springframework.cache.CacheManager;
 
 /**
  * @author E.Santoboni
  */
 public class TestContentListHelper extends BaseTestCase {
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		this.init();
-	}
+    private IContentManager contentManager;
+    private CacheManager springCacheManager;
+    private IPageManager pageManager = null;
+    private IWidgetTypeManager widgetTypeManager;
+    private IContentListWidgetHelper helper;
 
-	public void testGetFilters() throws Throwable {
-		String filtersShowletParam = "(key=DataInizio;attributeFilter=true;start=21/10/2007;order=DESC)+(key=Titolo;attributeFilter=true;order=ASC)";
-		EntitySearchFilter[] filters = this._helper.getFilters("EVN", filtersShowletParam, this.getRequestContext());
-		assertEquals(2, filters.length);
-		EntitySearchFilter filter = filters[0];
-		assertEquals("DataInizio", filter.getKey());
-		assertEquals(DateConverter.parseDate("21/10/2007", "dd/MM/yyyy"), filter.getStart());
-		assertNull(filter.getEnd());
-		assertNull(filter.getValue());
-		assertEquals("DESC", filter.getOrder().toString());
-	}
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        this.init();
+    }
 
-	public void testGetFilters_OneDefinition() {
-		RequestContext reqCtx = this.getRequestContext();
-		String contentType = "ART";
-		String showletParam = "(key=Titolo;attributeFilter=TRUE;start=START;end=END;like=FALSE;order=ASC)";
-		EntitySearchFilter[] filters = this._helper.getFilters(contentType, showletParam, reqCtx);
+    public void testGetFilters() throws Throwable {
+        String filtersShowletParam = "(key=DataInizio;attributeFilter=true;start=21/10/2007;order=DESC)+(key=Titolo;attributeFilter=true;order=ASC)";
+        EntitySearchFilter[] filters = this.helper.getFilters("EVN", filtersShowletParam, this.getRequestContext());
+        assertEquals(2, filters.length);
+        EntitySearchFilter filter = filters[0];
+        assertEquals("DataInizio", filter.getKey());
+        assertEquals(DateConverter.parseDate("21/10/2007", "dd/MM/yyyy"), filter.getStart());
+        assertNull(filter.getEnd());
+        assertNull(filter.getValue());
+        assertEquals("DESC", filter.getOrder().toString());
+    }
 
-		assertNotNull(filters);
-		assertEquals(1, filters.length);
+    public void testGetFilters_OneDefinition() {
+        RequestContext reqCtx = this.getRequestContext();
+        String contentType = "ART";
+        String showletParam = "(key=Titolo;attributeFilter=TRUE;start=START;end=END;like=FALSE;order=ASC)";
+        EntitySearchFilter[] filters = this.helper.getFilters(contentType, showletParam, reqCtx);
 
-		EntitySearchFilter entitySearchFilter = filters[0];
-		assertNotNull(entitySearchFilter);
+        assertNotNull(filters);
+        assertEquals(1, filters.length);
 
-		assertEquals("Titolo", entitySearchFilter.getKey());
-		assertEquals("START", entitySearchFilter.getStart());
-		assertEquals("END", entitySearchFilter.getEnd());
-		assertEquals("ASC", entitySearchFilter.getOrder().toString());
+        EntitySearchFilter entitySearchFilter = filters[0];
+        assertNotNull(entitySearchFilter);
 
-		contentType = "ART";
-		showletParam = "(key=Titolo;attributeFilter=TRUE;start=START;end=END;like=FALSE;order=DESC)";
-		filters = this._helper.getFilters(contentType, showletParam, reqCtx);
+        assertEquals("Titolo", entitySearchFilter.getKey());
+        assertEquals("START", entitySearchFilter.getStart());
+        assertEquals("END", entitySearchFilter.getEnd());
+        assertEquals("ASC", entitySearchFilter.getOrder().toString());
 
-		assertNotNull(filters);
-		assertEquals(1, filters.length);
+        contentType = "ART";
+        showletParam = "(key=Titolo;attributeFilter=TRUE;start=START;end=END;like=FALSE;order=DESC)";
+        filters = this.helper.getFilters(contentType, showletParam, reqCtx);
 
-		entitySearchFilter = filters[0];
-		assertNotNull(entitySearchFilter);
+        assertNotNull(filters);
+        assertEquals(1, filters.length);
 
-		assertEquals("Titolo", entitySearchFilter.getKey());
-		assertEquals("START", entitySearchFilter.getStart());
-		assertEquals("END", entitySearchFilter.getEnd());
-		assertEquals("DESC", entitySearchFilter.getOrder().toString());
+        entitySearchFilter = filters[0];
+        assertNotNull(entitySearchFilter);
 
-		contentType = "ART";
-		showletParam = "(key=descr;value=VALUE;attributeFilter=FALSE;order=ASC)";
-		filters = this._helper.getFilters(contentType, showletParam, reqCtx);
+        assertEquals("Titolo", entitySearchFilter.getKey());
+        assertEquals("START", entitySearchFilter.getStart());
+        assertEquals("END", entitySearchFilter.getEnd());
+        assertEquals("DESC", entitySearchFilter.getOrder().toString());
 
-		assertNotNull(filters);
-		assertEquals(1, filters.length);
+        contentType = "ART";
+        showletParam = "(key=descr;value=VALUE;attributeFilter=FALSE;order=ASC)";
+        filters = this.helper.getFilters(contentType, showletParam, reqCtx);
 
-		entitySearchFilter = filters[0];
-		assertNotNull(entitySearchFilter);
+        assertNotNull(filters);
+        assertEquals(1, filters.length);
 
-		assertEquals("descr", entitySearchFilter.getKey());
-		assertEquals(null, entitySearchFilter.getStart());
-		assertEquals(null, entitySearchFilter.getEnd());
-		assertEquals("ASC", entitySearchFilter.getOrder().toString());
-	}
+        entitySearchFilter = filters[0];
+        assertNotNull(entitySearchFilter);
 
-	public void testGetFilters_TwoDefinition() {
-		RequestContext reqCtx = this.getRequestContext();
-		String contentType = "ART";
-		String showletParam = "(key=Titolo;attributeFilter=TRUE;start=START;end=END;like=FALSE;order=ASC)+(key=descr;value=VALUE;attributeFilter=FALSE;order=ASC)";
-		EntitySearchFilter[] filters = this._helper.getFilters(contentType, showletParam, reqCtx);
+        assertEquals("descr", entitySearchFilter.getKey());
+        assertEquals(null, entitySearchFilter.getStart());
+        assertEquals(null, entitySearchFilter.getEnd());
+        assertEquals("ASC", entitySearchFilter.getOrder().toString());
+    }
 
-		assertNotNull(filters);
-		assertEquals(2, filters.length);
+    public void testGetFilters_TwoDefinition() {
+        RequestContext reqCtx = this.getRequestContext();
+        String contentType = "ART";
+        String showletParam = "(key=Titolo;attributeFilter=TRUE;start=START;end=END;like=FALSE;order=ASC)+(key=descr;value=VALUE;attributeFilter=FALSE;order=ASC)";
+        EntitySearchFilter[] filters = this.helper.getFilters(contentType, showletParam, reqCtx);
 
-		EntitySearchFilter entitySearchFilter = filters[0];
-		assertNotNull(entitySearchFilter);
+        assertNotNull(filters);
+        assertEquals(2, filters.length);
 
-		assertEquals("Titolo", entitySearchFilter.getKey());
-		assertEquals("START", entitySearchFilter.getStart());
-		assertEquals("END", entitySearchFilter.getEnd());
-		assertEquals("ASC", entitySearchFilter.getOrder().toString());
-		assertEquals(null, entitySearchFilter.getValue());
-		assertTrue(entitySearchFilter.isAttributeFilter());
+        EntitySearchFilter entitySearchFilter = filters[0];
+        assertNotNull(entitySearchFilter);
 
-		entitySearchFilter = filters[1];
-		assertNotNull(entitySearchFilter);
+        assertEquals("Titolo", entitySearchFilter.getKey());
+        assertEquals("START", entitySearchFilter.getStart());
+        assertEquals("END", entitySearchFilter.getEnd());
+        assertEquals("ASC", entitySearchFilter.getOrder().toString());
+        assertEquals(null, entitySearchFilter.getValue());
+        assertTrue(entitySearchFilter.isAttributeFilter());
 
-		assertEquals("descr", entitySearchFilter.getKey());
-		assertEquals(null, entitySearchFilter.getStart());
-		assertEquals(null, entitySearchFilter.getEnd());
-		assertEquals("ASC", entitySearchFilter.getOrder().toString());
-		assertFalse(entitySearchFilter.isAttributeFilter());
-		Object obj = entitySearchFilter.getValue();
-		assertNotNull(obj);
-		assertEquals(String.class, obj.getClass());
-		assertEquals("VALUE", (String) obj);
-	}
+        entitySearchFilter = filters[1];
+        assertNotNull(entitySearchFilter);
 
-	public void testGetContents_1() throws Throwable {
-		String pageCode = "pagina_1";
-		int frame = 1;
-		try {
-			this.setUserOnSession("guest");
-			RequestContext reqCtx = this.valueRequestContext(pageCode, frame);
-			MockContentListTagBean bean = new MockContentListTagBean();
-			bean.setContentType("EVN");
-			EntitySearchFilter filter = new EntitySearchFilter("DataInizio", true);
-			filter.setOrder(EntitySearchFilter.DESC_ORDER);
-			bean.addFilter(filter);
-			List<String> contents = this._helper.getContentsId(bean, reqCtx);
-			String[] expected = { "EVN194", "EVN193", "EVN24", "EVN23", "EVN25", "EVN20", "EVN21", "EVN192", "EVN191" };
-			assertEquals(expected.length, contents.size());
-			for (int i = 0; i < expected.length; i++) {
-				assertEquals(expected[i], contents.get(i));
-			}
-		} catch (Throwable t) {
-			throw t;
-		} finally {
-			this.setPageWidgets(pageCode, frame, null);
-		}
-	}
+        assertEquals("descr", entitySearchFilter.getKey());
+        assertEquals(null, entitySearchFilter.getStart());
+        assertEquals(null, entitySearchFilter.getEnd());
+        assertEquals("ASC", entitySearchFilter.getOrder().toString());
+        assertFalse(entitySearchFilter.isAttributeFilter());
+        Object obj = entitySearchFilter.getValue();
+        assertNotNull(obj);
+        assertEquals(String.class, obj.getClass());
+        assertEquals("VALUE", (String) obj);
+    }
 
-	public void testGetContents_2() throws Throwable {
-		String pageCode = "pagina_1";
-		int frame = 1;
-		try {
-			this.setUserOnSession("admin");
-			RequestContext reqCtx = this.valueRequestContext(pageCode, frame);
-			MockContentListTagBean bean = new MockContentListTagBean();
-			bean.setContentType("EVN");
-			bean.addCategory("evento");
-			EntitySearchFilter filter = new EntitySearchFilter("DataInizio", true);
-			filter.setOrder(EntitySearchFilter.DESC_ORDER);
-			bean.addFilter(filter);
-			List<String> contents = this._helper.getContentsId(bean, reqCtx);
-			String[] expected = { "EVN193", "EVN192" };
-			assertEquals(expected.length, contents.size());
-			for (int i = 0; i < expected.length; i++) {
-				assertEquals(expected[i], contents.get(i));
-			}
-		} catch (Throwable t) {
-			throw t;
-		} finally {
-			this.setPageWidgets(pageCode, frame, null);
-		}
-	}
+    public void testGetContents_1() throws Throwable {
+        String newContentId = null;
+        String pageCode = "pagina_1";
+        int frame = 1;
+        try {
+            this.setUserOnSession("guest");
+            RequestContext reqCtx = this.valueRequestContext(pageCode, frame);
+            MockContentListTagBean bean = new MockContentListTagBean();
+            bean.setContentType("EVN");
+            EntitySearchFilter filter = new EntitySearchFilter("DataInizio", true);
+            filter.setOrder(EntitySearchFilter.DESC_ORDER);
+            bean.addFilter(filter);
+            String cacheKey = ContentListHelper.buildCacheKey(bean, reqCtx);
+            assertNull(this.springCacheManager.getCache(ICacheInfoManager.DEFAULT_CACHE_NAME).get(cacheKey));
 
-	private RequestContext valueRequestContext(String pageCode, int frame) throws Throwable {
-		RequestContext reqCtx = this.getRequestContext();
-		try {
-			Widget widgetToAdd = this.getShowletForTest("content_viewer_list", null);
-			this.setPageWidgets(pageCode, frame, widgetToAdd);
+            List<String> contents = this.helper.getContentsId(bean, reqCtx);
+            String[] expected = {"EVN194", "EVN193", "EVN24", "EVN23", "EVN25", "EVN20", "EVN21", "EVN192", "EVN191"};
+            assertEquals(expected.length, contents.size());
+            for (int i = 0; i < expected.length; i++) {
+                assertEquals(expected[i], contents.get(i));
+            }
+            assertNotNull(this.springCacheManager.getCache(ICacheInfoManager.DEFAULT_CACHE_NAME).get(cacheKey));
 
-			IPage page = this._pageManager.getOnlinePage(pageCode);
-			reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_PAGE, page);
-			Widget widget = page.getWidgets()[frame];
-			reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_WIDGET, widget);
-			reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_FRAME, new Integer(frame));
-		} catch (Throwable t) {
-			this.setPageWidgets(pageCode, frame, null);
-			throw t;
-		}
-		return reqCtx;
-	}
+            Content content = this.contentManager.createContentType("EVN");
+            content.setDescription("Test Content");
+            content.setMainGroup(Group.FREE_GROUP_NAME);
+            contentManager.insertOnLineContent(content);
+            newContentId = content.getId();
+            assertNotNull(newContentId);
+            assertNull(this.springCacheManager.getCache(ICacheInfoManager.DEFAULT_CACHE_NAME).get(cacheKey));
+        } catch (Throwable t) {
+            throw t;
+        } finally {
+            this.setPageWidgets(pageCode, frame, null);
+            this.deleteTestContent(newContentId);
+        }
+    }
 
-	private void setPageWidgets(String pageCode, int frame, Widget widget) throws ApsSystemException {
-		IPage page = this._pageManager.getDraftPage(pageCode);
-		page.getWidgets()[frame] = widget;
-		page.getWidgets()[frame] = widget;
-		this._pageManager.updatePage(page);
-	}
+    public void testGetContents_2() throws Throwable {
+        String newContentId = null;
+        String pageCode = "pagina_1";
+        int frame = 1;
+        try {
+            this.setUserOnSession("admin");
+            RequestContext reqCtx = this.valueRequestContext(pageCode, frame);
+            MockContentListTagBean bean = new MockContentListTagBean();
+            bean.setContentType("EVN");
+            bean.addCategory("evento");
+            EntitySearchFilter filter = new EntitySearchFilter("DataInizio", true);
+            filter.setOrder(EntitySearchFilter.DESC_ORDER);
+            bean.addFilter(filter);
+            String cacheKey = ContentListHelper.buildCacheKey(bean, reqCtx);
+            assertNull(this.springCacheManager.getCache(ICacheInfoManager.DEFAULT_CACHE_NAME).get(cacheKey));
+            List<String> contents = this.helper.getContentsId(bean, reqCtx);
+            String[] expected = {"EVN193", "EVN192"};
+            assertEquals(expected.length, contents.size());
+            for (int i = 0; i < expected.length; i++) {
+                assertEquals(expected[i], contents.get(i));
+            }
+            assertNotNull(this.springCacheManager.getCache(ICacheInfoManager.DEFAULT_CACHE_NAME).get(cacheKey));
 
-	private Widget getShowletForTest(String showletTypeCode, ApsProperties config) throws Throwable {
-		WidgetType type = this._showletTypeManager.getWidgetType(showletTypeCode);
-		Widget widget = new Widget();
-		widget.setType(type);
-		if (null != config) {
-			widget.setConfig(config);
-		}
-		return widget;
-	}
+            Content content = this.contentManager.createContentType("EVN");
+            content.setDescription("Test Content");
+            content.setMainGroup(Group.ADMINS_GROUP_NAME);
+            contentManager.insertOnLineContent(content);
+            newContentId = content.getId();
+            assertNotNull(newContentId);
+            assertNull(this.springCacheManager.getCache(ICacheInfoManager.DEFAULT_CACHE_NAME).get(cacheKey));
 
-	private void init() throws Exception {
-		try {
-			this._pageManager = (IPageManager) this.getService(SystemConstants.PAGE_MANAGER);
-			this._showletTypeManager = (IWidgetTypeManager) this.getService(SystemConstants.WIDGET_TYPE_MANAGER);
-			this._helper = (IContentListWidgetHelper) this.getApplicationContext().getBean(JacmsSystemConstants.CONTENT_LIST_HELPER);
-		} catch (Throwable t) {
-			throw new Exception(t);
-		}
-	}
+        } catch (Throwable t) {
+            throw t;
+        } finally {
+            this.setPageWidgets(pageCode, frame, null);
+            this.deleteTestContent(newContentId);
+        }
+    }
 
-	private IPageManager _pageManager = null;
-	private IWidgetTypeManager _showletTypeManager;
-	private IContentListWidgetHelper _helper;
+    public void testGetContents_3() throws Throwable {
+        String newContentId = null;
+        String pageCode = "pagina_1";
+        int frame = 1;
+        try {
+            List<String> userGroupCodes = new ArrayList<>();
+            userGroupCodes.add(Group.ADMINS_GROUP_NAME);
+            List<String> contents = this.contentManager.loadPublicContentsId("ART", null, null, userGroupCodes);
+
+            this.setUserOnSession("admin");
+            RequestContext reqCtx = this.valueRequestContext(pageCode, frame);
+            MockContentListTagBean bean = new MockContentListTagBean();
+            bean.setContentType("ART");
+
+            String cacheKey = ContentListHelper.buildCacheKey(bean, reqCtx);
+            assertNull(this.springCacheManager.getCache(ICacheInfoManager.DEFAULT_CACHE_NAME).get(cacheKey));
+
+            List<String> extractedContents = this.helper.getContentsId(bean, reqCtx);
+            assertEquals(contents.size(), extractedContents.size());
+            CollectionUtils.containsAll(extractedContents, contents);
+
+            assertNotNull(this.springCacheManager.getCache(ICacheInfoManager.DEFAULT_CACHE_NAME).get(cacheKey));
+
+            Content content = this.contentManager.createContentType("ART");
+            content.setDescription("Test Content");
+            content.setMainGroup(Group.ADMINS_GROUP_NAME);
+            contentManager.insertOnLineContent(content);
+            newContentId = content.getId();
+            assertNotNull(newContentId);
+            assertNull(this.springCacheManager.getCache(ICacheInfoManager.DEFAULT_CACHE_NAME).get(cacheKey));
+        } catch (Throwable t) {
+            throw t;
+        } finally {
+            this.setPageWidgets(pageCode, frame, null);
+            this.deleteTestContent(newContentId);
+        }
+    }
+
+    private void deleteTestContent(String newContentId) throws ApsSystemException {
+        if (null != newContentId) {
+            Content newContent = this.contentManager.loadContent(newContentId, false);
+            if (null != newContent) {
+                this.contentManager.removeOnLineContent(newContent);
+                this.contentManager.deleteContent(newContent);
+                assertNull(this.contentManager.loadContent(newContentId, false));
+            }
+        }
+    }
+
+    private RequestContext valueRequestContext(String pageCode, int frame) throws Throwable {
+        RequestContext reqCtx = this.getRequestContext();
+        try {
+            Widget widgetToAdd = this.getwidgetForTest("content_viewer_list", null);
+            this.setPageWidgets(pageCode, frame, widgetToAdd);
+
+            IPage page = this.pageManager.getOnlinePage(pageCode);
+            reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_PAGE, page);
+            Widget widget = page.getWidgets()[frame];
+            reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_WIDGET, widget);
+            reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_FRAME, new Integer(frame));
+        } catch (Throwable t) {
+            this.setPageWidgets(pageCode, frame, null);
+            throw t;
+        }
+        return reqCtx;
+    }
+
+    private void setPageWidgets(String pageCode, int frame, Widget widget) throws ApsSystemException {
+        IPage page = this.pageManager.getDraftPage(pageCode);
+        page.getWidgets()[frame] = widget;
+        page.getWidgets()[frame] = widget;
+        this.pageManager.updatePage(page);
+    }
+
+    private Widget getwidgetForTest(String widgetTypeCode, ApsProperties config) throws Throwable {
+        WidgetType type = this.widgetTypeManager.getWidgetType(widgetTypeCode);
+        Widget widget = new Widget();
+        widget.setType(type);
+        if (null != config) {
+            widget.setConfig(config);
+        }
+        return widget;
+    }
+
+    private void init() throws Exception {
+        try {
+            this.springCacheManager = (CacheManager) this.getApplicationContext().getBean(CacheManager.class);
+            this.contentManager = (IContentManager) this.getService(JacmsSystemConstants.CONTENT_MANAGER);
+            this.pageManager = (IPageManager) this.getService(SystemConstants.PAGE_MANAGER);
+            this.widgetTypeManager = (IWidgetTypeManager) this.getService(SystemConstants.WIDGET_TYPE_MANAGER);
+            this.helper = (IContentListWidgetHelper) this.getApplicationContext().getBean(JacmsSystemConstants.CONTENT_LIST_HELPER);
+        } catch (Throwable t) {
+            throw new Exception(t);
+        }
+    }
 
 }


### PR DESCRIPTION
The problem was found in the content list widget.
when in a content list we create a filter directly on the jsp, and this filter is dynamic (for example based on the attributes of the current user), the key with which the object is cached is the same and the resulting list is always the same.
This PR fixes this problem