### PR TITLE
[4.3.4] EN-1914-434-Digital-Assets-Impossible-to-add-file-with-null-value-metadata

### DIFF
--- a/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/resource/parse/ResourceDOM.java
+++ b/engine/src/main/java/com/agiletec/plugins/jacms/aps/system/services/resource/parse/ResourceDOM.java
@@ -141,14 +141,15 @@ public class ResourceDOM {
      */
    
     public void addMetadata(Map<String, String> metadata) {
-        
         if (null != metadata) {
-            
             metadata.forEach((k, v) -> {
-            
                 Element metadataElement = new Element("metadata");
                 metadataElement.setAttribute("id", k.trim());
-                metadataElement.setText(v.trim());
+                if (null != v) {
+                    metadataElement.setText(v.trim());
+                } else {
+                    metadataElement.setText("");
+                }
                 this._root.getChild(TAG_METADATA).addContent(metadataElement);
             });
         }


### PR DESCRIPTION
Hi @joewhite101 @eugeniosant ,
Null metadata value check added.
Could you please take a look at this PR?

Thanks!