### PR TITLE
[4.3.4] EN-1924-434-CMS-menu-contents-settings-labels

### DIFF
--- a/admin-console/src/main/java/com/agiletec/apsadmin/global-messages_it.properties
+++ b/admin-console/src/main/java/com/agiletec/apsadmin/global-messages_it.properties
@@ -296,6 +296,7 @@ menu.languageAdmin.labels=Etichette
 menu.reload=Ricarica
 menu.reload.config=Ricarica la configurazione
 menu.reload.contents=Ricarica i contenuti
+menu.contents.settings=Impostazione Contenuti
 
 menu.entityAdmin=Entit&agrave;
 menu.entityAdmin.long=Gestisci le Entit&agrave;, come per esempio i Tipi di Contenuto o un qualsiasi altro Tipo di Entit&agrave; fornito da un determinato Plugin


### PR DESCRIPTION
Hey @joewhite101 @eugeniosant ,
Missing Settings Italian label added.
Could you please have a look?

Thanks!