### PR TITLE
En 2359

### DIFF
--- a/engine/src/main/resources/spring/aps/managers/apiManagersConfig.xml
+++ b/engine/src/main/resources/spring/aps/managers/apiManagersConfig.xml
@@ -53,7 +53,7 @@
         <property name="consumerDAO">
             <bean class="org.entando.entando.aps.system.services.oauth2.OAuthConsumerDAO">
                 <property name="dataSource" ref="servDataSource"/>
-                <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/servDataSourceClassName" /></property>
+                <property name="dataSourceClassName"><value>${servDataSourceClassName}</value></property>
             </bean>
         </property>
         <property name="accessTokenValiditySeconds"><value>${oauth2.accessToken.validitySeconds}</value></property>

--- a/engine/src/main/resources/spring/aps/managers/baseManagersConfig.xml
+++ b/engine/src/main/resources/spring/aps/managers/baseManagersConfig.xml
@@ -105,16 +105,16 @@
                     <value>${file.upload.maxSize}</value>
                 </entry>
                 <entry key="configVersion">
-                    <jee:jndi-lookup jndi-name="java:comp/env/configVersion" />
+                    <value>${configVersion}</value>
                 </entry>
                 <entry key="applicationBaseURL">
-                    <jee:jndi-lookup jndi-name="java:comp/env/applicationBaseURL" />
+                    <value>${applicationBaseURL}</value>
                 </entry>
                 <entry key="resourceRootURL">
-                    <jee:jndi-lookup jndi-name="java:comp/env/resourceRootURL" />
+                    <value>${resourceRootURL}</value>
                 </entry>
                 <entry key="resourceDiskRootFolder">
-                    <jee:jndi-lookup jndi-name="java:comp/env/resourceDiskRootFolder" />
+                    <value>${resourceDiskRootFolder}</value>
                 </entry>
             </map>
         </property>

--- a/engine/src/main/resources/spring/aps/managers/baseManagersConfig.xml
+++ b/engine/src/main/resources/spring/aps/managers/baseManagersConfig.xml
@@ -138,7 +138,7 @@
         <property name="groupDAO" >
             <bean class="com.agiletec.aps.system.services.group.GroupDAO">
                 <property name="dataSource" ref="servDataSource" />
-                <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/servDataSourceClassName" /></property>
+                <property name="dataSourceClassName"><value>${servDataSourceClassName}</value></property>
             </bean>
         </property>
         <property name="cacheWrapper">
@@ -192,7 +192,7 @@
         <property name="authorizationDAO" >
             <bean class="com.agiletec.aps.system.services.authorization.AuthorizationDAO">
                 <property name="dataSource" ref="servDataSource" />
-                <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/servDataSourceClassName" /></property>
+                <property name="dataSourceClassName"><value>${servDataSourceClassName}</value></property>
             </bean>
         </property>
     </bean>
@@ -259,7 +259,7 @@
         <property name="guiFragmentDAO">
             <bean class="org.entando.entando.aps.system.services.guifragment.GuiFragmentDAO">
                 <property name="dataSource" ref="portDataSource" />
-                <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/portDataSourceClassName" /></property>
+                <property name="dataSourceClassName"><value>${portDataSourceClassName}</value></property>
             </bean>
         </property>
     </bean>
@@ -274,7 +274,7 @@
             <bean class="com.agiletec.aps.system.services.pagemodel.PageModelDAO">
                 <property name="dataSource" ref="portDataSource" />
                 <property name="widgetTypeManager" ref="WidgetTypeManager" />
-                <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/portDataSourceClassName" /></property>
+                <property name="dataSourceClassName"><value>${portDataSourceClassName}</value></property>
             </bean>
         </property>
         <property name="cacheWrapper">
@@ -359,7 +359,7 @@
         <property name="actionLogDAO">
             <bean class="org.entando.entando.aps.system.services.actionlog.ActionLogDAO">
                 <property name="dataSource" ref="servDataSource" />
-                <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/servDataSourceClassName" /></property>
+                <property name="dataSourceClassName"><value>${servDataSourceClassName}</value></property>
             </bean>
         </property>
         <property name="managerConfiguration" ref="ActionLogManagerConfiguration" />

--- a/engine/src/main/resources/spring/aps/managers/dataManagersConfig.xml
+++ b/engine/src/main/resources/spring/aps/managers/dataManagersConfig.xml
@@ -93,7 +93,7 @@
             <bean class="org.entando.entando.aps.system.services.dataobjectsearchengine.SearchEngineDAOFactory"
                   init-method="init">
                 <property name="indexDiskRootFolder">
-                    <jee:jndi-lookup jndi-name="java:comp/env/indexDiskRootFolder" />
+                    <value>${indexDiskRootFolder}</value>
                 </property>
                 <property name="configManager" ref="BaseConfigManager"/>
                 <property name="langManager" ref="LangManager" />

--- a/engine/src/main/resources/spring/aps/managers/dataManagersConfig.xml
+++ b/engine/src/main/resources/spring/aps/managers/dataManagersConfig.xml
@@ -16,7 +16,7 @@
         <property name="dataModelDAO" >
             <bean class="org.entando.entando.aps.system.services.dataobjectmodel.DataObjectModelDAO">
                 <property name="dataSource" ref="servDataSource" />
-                <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/servDataSourceClassName" /></property>
+                <property name="dataSourceClassName"><value>${servDataSourceClassName}</value></property>
             </bean>
         </property>
 		<property name="cacheWrapper">
@@ -54,7 +54,7 @@
     <bean id="DataObjectSearcherDAO" class="org.entando.entando.aps.system.services.dataobject.DataObjectSearcherDAO">
         <property name="dataSource" ref="servDataSource" />
         <property name="dataSourceClassName">
-            <jee:jndi-lookup jndi-name="java:comp/env/servDataSourceClassName" />
+            <value>${servDataSourceClassName}</value>
         </property>
     </bean>
 

--- a/engine/src/main/resources/spring/aps/managers/userprofileManagers.xml
+++ b/engine/src/main/resources/spring/aps/managers/userprofileManagers.xml
@@ -31,7 +31,7 @@
             <bean class="org.entando.entando.aps.system.services.userprofile.UserProfileSearcherDAO">
                 <property name="dataSource" ref="servDataSource" />
                 <property name="dataSourceClassName">
-                    <jee:jndi-lookup jndi-name="java:comp/env/servDataSourceClassName" />
+                    <value>${servDataSourceClassName}</value>
                 </property>
             </bean>
         </property>

--- a/engine/src/main/resources/spring/baseSystemConfig.xml
+++ b/engine/src/main/resources/spring/baseSystemConfig.xml
@@ -13,9 +13,9 @@
 
     <context:annotation-config />
 
-    <jee:jndi-lookup id="portDataSource" jndi-name="java:comp/env/jdbc/portDataSource"/>
+    <jee:jndi-lookup id="portDataSource" jndi-name="${portdb.jndi:java:comp/env/jdbc/portDataSource}"/>
 
-    <jee:jndi-lookup id="servDataSource" jndi-name="java:comp/env/jdbc/servDataSource"/>
+    <jee:jndi-lookup id="servDataSource" jndi-name="${servdb.jndi:java:comp/env/jdbc/servDataSource}"/>
 
     <bean id="ApsSystemUtils" class="com.agiletec.aps.system.ApsSystemUtils" init-method="init" >
         <property name="systemParams">

--- a/engine/src/main/resources/spring/baseSystemConfig.xml
+++ b/engine/src/main/resources/spring/baseSystemConfig.xml
@@ -20,12 +20,12 @@
     <bean id="ApsSystemUtils" class="com.agiletec.aps.system.ApsSystemUtils" init-method="init" >
         <property name="systemParams">
             <map>
-                <entry key="logActiveFileOutput"><jee:jndi-lookup jndi-name="java:comp/env/logActiveFileOutput" /></entry>
-                <entry key="logName"><jee:jndi-lookup jndi-name="java:comp/env/logName" /></entry>
-                <entry key="logFilePrefix"><jee:jndi-lookup jndi-name="java:comp/env/logFilePrefix" /></entry>
-                <entry key="logLevel"><jee:jndi-lookup jndi-name="java:comp/env/logLevel" /></entry>
-                <entry key="logFileSize"><jee:jndi-lookup jndi-name="java:comp/env/logFileSize" /></entry>
-                <entry key="logFilesCount"><jee:jndi-lookup jndi-name="java:comp/env/logFilesCount" /></entry>
+                <entry key="logActiveFileOutput"><value>${logActiveFileOutput}</value></entry>
+                <entry key="logName"  ><value>${logName}</value></entry>
+                <entry key="logFilePrefix"><value>${logFilePrefix}</value></entry>
+                <entry key="logLevel"><value>${logLevel}</value></entry>
+                <entry key="logFileSize"><value>${logFileSize}</value></entry>
+                <entry key="logFilesCount"><value>${logFilesCount}</value></entry>
             </map>
         </property>
     </bean>
@@ -84,16 +84,16 @@
     <bean id="StorageManager" class="org.entando.entando.aps.system.services.storage.LocalStorageManager"
           init-method="init" >
         <property name="baseURL" >
-            <jee:jndi-lookup jndi-name="java:comp/env/resourceRootURL" />
+            <value>${resourceRootURL}</value>
         </property>
         <property name="baseDiskRoot" >
-            <jee:jndi-lookup jndi-name="java:comp/env/resourceDiskRootFolder" />
+            <value>${resourceDiskRootFolder}</value>
         </property>
         <property name="protectedBaseDiskRoot" >
-            <jee:jndi-lookup jndi-name="java:comp/env/protectedResourceDiskRootFolder" />
+            <value>${protectedResourceDiskRootFolder}</value>
         </property>
         <property name="protectedBaseURL" >
-            <jee:jndi-lookup jndi-name="java:comp/env/protectedResourceRootURL" />
+            <value>${protectedResourceRootURL}</value>
         </property>
     </bean>
 
@@ -172,7 +172,7 @@
     <bean id="abstractInitializerManager" class="org.entando.entando.aps.system.init.AbstractInitializerManager"
           abstract="true" init-method="init">
         <property name="configVersion">
-            <jee:jndi-lookup jndi-name="java:comp/env/configVersion" />
+            <value>${configVersion}</value>
         </property>
         <property name="environment">
             <value>${db.environment}</value>

--- a/src/test/config/conf/systemParams.properties
+++ b/src/test/config/conf/systemParams.properties
@@ -24,9 +24,9 @@ imagemagick.path=null
 #imagemagick.windows=true
 #imagemagick.path=C:\\Programmi\\ImageMagick-6.6.3-Q16
 
-
-portDataSourceClassName=${profile.database.driverClassName}
-servDataSourceClassName=${profile.database.driverClassName}
+#These properties should be resolved from java:comp/env
+#portDataSourceClassName=${profile.database.driverClassName}
+#servDataSourceClassName=${profile.database.driverClassName}
 
 
 ##----------------------


### PR DESCRIPTION
I have modified a couple of Spring xml configs to use property placeholders, e.g. ${my.prop} instead of JNDI Environment Entry lookups. As discussed in the Spring documentation (https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html), this allows existing JNDI Environment Entries to still take precedence for legacy projects, but allows new projects to omit these entries in favour of OS environment variables. This has been extremely useful in making our images more flexible and dynamically configurable.