### PR TITLE
EN-2393 Fixed issues in Consumer API

### DIFF
--- a/admin-console/src/main/webapp/WEB-INF/apsadmin/jsp/api/consumer-entry.jsp
+++ b/admin-console/src/main/webapp/WEB-INF/apsadmin/jsp/api/consumer-entry.jsp
@@ -82,7 +82,7 @@
     <div class="form-group<s:property value="#controlGroupErrorClassVar" />">
         <label class="col-sm-2 control-label" for="secret"><s:text name="label.secret" /></label>
         <div class="col-sm-10">
-            <wpsf:textfield name="secret" id="secret" cssClass="form-control" />
+            <wpsf:password name="secret" id="secret" cssClass="form-control" placeholder="********" />
             <s:if test="#currentFieldHasFieldErrorVar">
                 <span class="text-danger padding-small-vertical"><s:iterator value="#currentFieldErrorsVar"><s:property />&#32;</s:iterator></span>
             </s:if>

--- a/engine/src/main/java/org/entando/entando/aps/system/services/oauth2/model/ApiConsumer.java
+++ b/engine/src/main/java/org/entando/entando/aps/system/services/oauth2/model/ApiConsumer.java
@@ -14,7 +14,7 @@
 package org.entando.entando.aps.system.services.oauth2.model;
 
 import com.agiletec.aps.system.SystemConstants;
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.agiletec.aps.util.DateConverter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,11 +50,10 @@ public class ApiConsumer {
     private String callbackUrl;
     private String scope;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = SystemConstants.API_DATE_FORMAT)
-    private Date issuedDate;
+    private String issuedDate;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = SystemConstants.API_DATE_FORMAT)
-    private Date expirationDate;
+    @NotBlank(message = "string.notBlank")
+    private String expirationDate;
 
     private List<String> authorizedGrantTypes;
 
@@ -71,8 +70,8 @@ public class ApiConsumer {
         description = vo.getDescription();
         callbackUrl = vo.getCallbackUrl();
         scope = vo.getScope();
-        expirationDate = vo.getExpirationDate();
-        issuedDate = vo.getIssuedDate();
+        expirationDate = formatDate(vo.getExpirationDate());
+        issuedDate = formatDate(vo.getIssuedDate());
 
         if (!StringUtils.isEmpty(vo.getAuthorizedGrantTypes())) {
             authorizedGrantTypes = Arrays.asList(vo.getAuthorizedGrantTypes().split(","));
@@ -127,19 +126,19 @@ public class ApiConsumer {
         this.scope = scope;
     }
 
-    public Date getExpirationDate() {
+    public String getExpirationDate() {
         return expirationDate;
     }
 
-    public void setExpirationDate(Date expirationDate) {
+    public void setExpirationDate(String expirationDate) {
         this.expirationDate = expirationDate;
     }
 
-    public Date getIssuedDate() {
+    public String getIssuedDate() {
         return issuedDate;
     }
 
-    public void setIssuedDate(Date issuedDate) {
+    public void setIssuedDate(String issuedDate) {
         this.issuedDate = issuedDate;
     }
 
@@ -161,13 +160,21 @@ public class ApiConsumer {
         vo.setDescription(description);
         vo.setCallbackUrl(callbackUrl);
         vo.setScope(scope);
-        vo.setExpirationDate(expirationDate);
-        vo.setIssuedDate(issuedDate);
+        vo.setExpirationDate(getDate(expirationDate));
+        vo.setIssuedDate(getDate(issuedDate));
 
         if (authorizedGrantTypes != null) {
             vo.setAuthorizedGrantTypes(String.join(",", authorizedGrantTypes));
         }
 
         return vo;
+    }
+
+    private Date getDate(String formattedDate) {
+        return DateConverter.parseDate(formattedDate, SystemConstants.API_DATE_FORMAT);
+    }
+
+    private String formatDate(Date date) {
+        return DateConverter.getFormattedDate(date, SystemConstants.API_DATE_FORMAT);
     }
 }

--- a/engine/src/main/java/org/entando/entando/web/api/oauth2/validator/ApiConsumerValidator.java
+++ b/engine/src/main/java/org/entando/entando/web/api/oauth2/validator/ApiConsumerValidator.java
@@ -13,7 +13,10 @@
  */
 package org.entando.entando.web.api.oauth2.validator;
 
+import com.agiletec.aps.system.SystemConstants;
+import com.agiletec.aps.util.DateConverter;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.entando.entando.web.common.validator.AbstractPaginationValidator;
@@ -31,6 +34,7 @@ public class ApiConsumerValidator extends AbstractPaginationValidator {
 
     public static final String ERRCODE_INVALID_GRANT_TYPE = "2";
     public static final String ERRCODE_URINAME_MISMATCH = "3";
+    public static final String ERRCODE_INVALID_DATE = "4";
 
     @Override
     public boolean supports(Class<?> clazz) {
@@ -41,13 +45,28 @@ public class ApiConsumerValidator extends AbstractPaginationValidator {
     public void validate(Object target, Errors errors) {
         if (target instanceof ApiConsumer) {
             ApiConsumer consumer = (ApiConsumer) target;
+            validateGrantTypes(consumer.getAuthorizedGrantTypes(), errors);
+            validateDate(consumer.getIssuedDate(), "issuedDate", errors);
+            validateDate(consumer.getExpirationDate(), "expirationDate", errors);
+        }
+    }
 
-            List<String> validGrantTypes = Arrays.asList(IOAuthConsumerManager.GRANT_TYPES);
+    private void validateGrantTypes(List<String> grantTypes, Errors errors) {
 
-            for (String grantType : consumer.getAuthorizedGrantTypes()) {
-                if (!validGrantTypes.contains(grantType)) {
-                    errors.reject(ERRCODE_INVALID_GRANT_TYPE, new String[]{grantType}, "api.consumer.grantType.invalid");
-                }
+        List<String> validGrantTypes = Arrays.asList(IOAuthConsumerManager.GRANT_TYPES);
+
+        for (String grantType : grantTypes) {
+            if (!validGrantTypes.contains(grantType)) {
+                errors.reject(ERRCODE_INVALID_GRANT_TYPE, new String[]{grantType}, "api.consumer.grantType.invalid");
+            }
+        }
+    }
+
+    private void validateDate(String date, String fieldName, Errors errors) {
+        if (date != null) {
+            Date parsedDate = DateConverter.parseDate(date, SystemConstants.API_DATE_FORMAT);
+            if (parsedDate == null) {
+                errors.rejectValue(fieldName, ERRCODE_INVALID_DATE, new String[]{date}, "api.consumer.date.invalid");
             }
         }
     }

--- a/engine/src/main/resources/rest/messages.properties
+++ b/engine/src/main/resources/rest/messages.properties
@@ -292,6 +292,7 @@ entity.typeCode.notBlank=TypeCode is required
 api.consumer.grantType.invalid=''{0}'' is not a valid grant type
 api.consumer.exists=A consumer having key ''{0}'' already exists
 api.consumer.key.mismatch=The key specified the URI ''{0}'' does not match with the one provided in the payload ''{1}''
+api.consumer.date.invalid=The date ''{0}'' has an invalid format. Required format is 'yyyy-MM-dd HH:mm:ss'
 
 #Digital Exchange
 digitalExchange.notFound=Digital Exchange ''{0}'' not found

--- a/engine/src/test/java/org/entando/entando/web/api/oauth2/ApiConsumerControllerIntegrationTest.java
+++ b/engine/src/test/java/org/entando/entando/web/api/oauth2/ApiConsumerControllerIntegrationTest.java
@@ -15,13 +15,11 @@ package org.entando.entando.web.api.oauth2;
 
 import com.agiletec.aps.system.SystemConstants;
 import com.agiletec.aps.system.services.user.UserDetails;
+import com.agiletec.aps.util.DateConverter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.TimeZone;
 import org.entando.entando.aps.system.services.oauth2.OAuthConsumerManager;
 import org.entando.entando.aps.system.services.oauth2.model.ApiConsumer;
 import org.entando.entando.aps.system.services.oauth2.model.ConsumerRecordVO;
@@ -208,7 +206,7 @@ public class ApiConsumerControllerIntegrationTest extends AbstractControllerInte
         consumer.setName("Consumer 1");
         consumer.setDescription("descr");
         consumer.setSecret("secret");
-        consumer.setExpirationDate(getDate(EXPIRATION_DATE));
+        consumer.setExpirationDate(EXPIRATION_DATE);
         consumer.setAuthorizedGrantTypes(Arrays.asList("authorization_code", "implicit"));
         consumer.setScope("scope");
         consumer.setCallbackUrl("http://entando.org");
@@ -254,13 +252,7 @@ public class ApiConsumerControllerIntegrationTest extends AbstractControllerInte
     }
 
     private Date getDate(String date) {
-        SimpleDateFormat sdf = new SimpleDateFormat(SystemConstants.API_DATE_FORMAT);
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        try {
-            return sdf.parse(date);
-        } catch (ParseException ex) {
-            throw new RuntimeException(ex);
-        }
+        return DateConverter.parseDate(date, SystemConstants.API_DATE_FORMAT);
     }
 
     private ResultActions authRequest(MockHttpServletRequestBuilder requestBuilder) throws Exception {

--- a/engine/src/test/java/org/entando/entando/web/api/oauth2/ApiConsumerControllerTest.java
+++ b/engine/src/test/java/org/entando/entando/web/api/oauth2/ApiConsumerControllerTest.java
@@ -134,6 +134,12 @@ public class ApiConsumerControllerTest extends AbstractControllerTest {
 
         testValidationErrorPost(c -> c.getAuthorizedGrantTypes().add("invalid_grant"))
                 .andExpect(jsonPath("$.errors[0].code", is("2")));
+        
+        testValidationErrorPost(c -> c.setExpirationDate("invalid-date"))
+                .andExpect(jsonPath("$.errors[0].code", is("4")));
+
+        testValidationErrorPost(c -> c.setIssuedDate("invalid-date"))
+                .andExpect(jsonPath("$.errors[0].code", is("4")));
     }
 
     private ResultActions testValidationErrorPost(Consumer<ApiConsumer> consumer) throws Exception {
@@ -158,6 +164,7 @@ public class ApiConsumerControllerTest extends AbstractControllerTest {
         apiConsumer.setName("name");
         apiConsumer.setSecret("secret");
         apiConsumer.setDescription("description");
+        apiConsumer.setExpirationDate("2020-01-01 00:00:00");
         return apiConsumer;
     }
 


### PR DESCRIPTION
It seems that there is a timezone conversion issue when Jackson deserialize the dates (I found some threads on GitHub about this). To solve the issue I changed the field type from `Date` to `String` and I performed the date validation/conversion manually (using the `DateConverter` class already provided by the Entando core).