### PR TITLE
Bump version to 6.0.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It provides the basic structure, tools, and functionality to build an instance o
 2. **admin-console**, includes tools to manage administrative core features and WCMS functionality
 3. **portal-ui**, provides tools to create interactive web apps UI/UX
 
-The Entando platform **v5.2.0-SNAPSHOT** project includes also the following Github projects:
+The Entando platform **v6.0.0-SNAPSHOT** project includes also the following Github projects:
 
 * **entando-components**: https://github.com/entando/entando-components. Entando platform relies on a number of components or extensions that add functionality not included with the standard Entando platform. There are two types of components: Plugins and Bundles. Plugins extend the functionality of Entando engine, admin-console and portal-ui; Bundles extend the functionality of UI/UX Applications.
 

--- a/admin-console/pom.xml
+++ b/admin-console/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>entando-core</artifactId>
         <groupId>org.entando.entando</groupId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.entando.entando</groupId>
     <artifactId>entando-admin-console</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Entando Core: Administration Console</name>
     <description>Entando Administration Console: an agile, modern and user-centric open source Portal platform.</description>
@@ -233,12 +233,12 @@
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-engine</artifactId>
-            <version>5.2.0-SNAPSHOT</version>
+            <version>6.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-engine</artifactId>
-            <version>5.2.0-SNAPSHOT</version>
+            <version>6.0.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>entando-core</artifactId>
         <groupId>org.entando.entando</groupId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.entando.entando</groupId>
     <artifactId>entando-engine</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <name>Entando Core: Engine</name>
     <description>Entando Engine: an agile, modern and user-centric open source Portal platform.</description>
     <url>http://www.entando.com/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.entando.entando</groupId>
     <artifactId>entando-core</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Entando Core</name>
     <description>Entando Core: an agile, modern and user-centric open source Portal platform.</description>

--- a/portal-ui/pom.xml
+++ b/portal-ui/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>entando-core</artifactId>
         <groupId>org.entando.entando</groupId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.entando.entando</groupId>
     <artifactId>entando-portal-ui</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Entando Core: Portal UI</name>
     <description>Entando Portal UI: an agile, modern and user-centric open source Portal platform.</description>
@@ -232,12 +232,12 @@
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-engine</artifactId>
-            <version>5.2.0-SNAPSHOT</version>
+            <version>6.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-engine</artifactId>
-            <version>5.2.0-SNAPSHOT</version>
+            <version>6.0.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -247,18 +247,18 @@
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-admin-console</artifactId>
-            <version>5.2.0-SNAPSHOT</version>
+            <version>6.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-admin-console</artifactId>
-            <version>5.2.0-SNAPSHOT</version>
+            <version>6.0.0-SNAPSHOT</version>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>org.entando.entando</groupId>
             <artifactId>entando-admin-console</artifactId>
-            <version>5.2.0-SNAPSHOT</version>
+            <version>6.0.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Next I'll update also the components (at least the digital-exchange and CMS) to this new version to support the entando-de-app