### PR TITLE
PDA-175: Fix saving page widget config

### DIFF
--- a/engine/src/main/java/org/entando/entando/web/common/interceptor/ActivityStreamInterceptor.java
+++ b/engine/src/main/java/org/entando/entando/web/common/interceptor/ActivityStreamInterceptor.java
@@ -112,18 +112,19 @@ public class ActivityStreamInterceptor extends HandlerInterceptorAdapter {
         return this.addParameters(prev, params);
     }
 
-    private String addParamsFromRequestBody(String prev, InputStream is) throws Exception {
+    private String addParamsFromRequestBody(String prev, InputStream is) {
         if (null == is) {
             return prev;
         }
-        CloseShieldInputStream cloned = new CloseShieldInputStream(is);
-        String body = FileTextReader.getText(cloned);
-        byte[] bytes = body.getBytes();
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
+            CloseShieldInputStream cloned = new CloseShieldInputStream(is);
+            String body = FileTextReader.getText(cloned);
+            byte[] bytes = body.getBytes();
+            ObjectMapper objectMapper = new ObjectMapper();
             Map<String, String> params = objectMapper.readValue(bytes, HashMap.class);
             return this.addParameters(prev, params);
         } catch (Exception e) {
+            logger.error("System exception {}", e.getMessage(), e);
             return prev;
         }
     }


### PR DESCRIPTION
IOException is being thrown and converted to `EntandoTokenException`, which causes the strange response below for the `/api/pages/<page_code>/widgets/<widget_code>` api:
```
{
    "payload": {
        "code": "pda_task_details",
        "config": {
            "settings": "{\"header\":\"taskDetails.overview.detailsTitle\",\"hasGeneralInformation\":true,\"destinationPageCode\":\"pda_task_details\"}",
            "knowledgeSource": "dev"
        }
    },
    "metaData": {
        "status": "draft"
    },
    "errors": []
}{
    "payload": [],
    "metaData": [],
    "errors": [
        {
            "code": "120",
            "message": "guest is not allowed to /entando-de-app/api/pages/pda_task_details/widgets/5 [PUT]"
        }
    ]
}
```
Notice there are 2 JSON root object on the response. This is causing issues on app-builder and the redirect doesn't happen after saving a widget configuration.
This fix increases the scope of the try block to also handle the IOException. So, a closed InputStream is going to return the same value as a null InputStream for the addParamsFromRequestBody method.
