### PR TITLE
ENG-407 Changing how we validate if the current password is correct

### DIFF
--- a/engine/src/main/java/org/entando/entando/web/user/validator/UserValidator.java
+++ b/engine/src/main/java/org/entando/entando/web/user/validator/UserValidator.java
@@ -209,8 +209,15 @@ public class UserValidator extends AbstractPaginationValidator {
     }
 
     private boolean verifyPassword(String username, String password) {
-        UserDetails user = this.extractUser(username);
-        return passwordEncoder.matches(password, user.getPassword());
+        try {
+            UserDetails user = this.getUserManager().getUser(username, password);
+            if (user != null) {
+                return true;
+            }
+        } catch (ApsSystemException e) {
+            logger.error("Invalid password for username {}", username, e);
+        }
+        return false;
     }
 
     private UserDetails extractUser(String username) {


### PR DESCRIPTION
You might noticed that I didn't add tests for this. We currently already have tests for the user changing its password:
	UserControllerIntegrationTest.testUpdatePassword_1() on core
	UserControllerIntegrationTest.testUpdatePassword_2() on core
	UserManagerIT.testUserUpdatePassword() on entando-keycloak-plugin
	
The logic didn't change, just the way we check if an old password is valid or not. This was necessary because we don't have access to what is the current password on keycloak.

After this change the legacy admin console still works, and the app builder works with keycloak and without it.